### PR TITLE
fix: use the same message prefix for signing as in sdk

### DIFF
--- a/scripts/prepare-devenv.sh
+++ b/scripts/prepare-devenv.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ -d clang-arm-fropi -a -d gcc-arm-none-eabi-5_3-2016q1 -a -d nanos-secure-sdk-f9e1c7b8904df2eee0ae7e603f552b876c169334 ]; then
-    echo "Devend is already prepared. Exiting."
+    echo "Devenv is already prepared. Exiting."
     exit
 fi
 

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -7,7 +7,7 @@ static uint32_t accountNumber;
 static uint8_t *data;
 static uint32_t dataLength;
 
-static const char SIGN_MAGIC[] = "æternity Signed Message:\n";
+static const char SIGN_MAGIC[] = "aeternity Signed Message:\n";
 
 static unsigned int io_seproxyhal_touch_signMessage_ok(const bagl_element_t *e) {
     uint8_t message[0xFC + sizeof(SIGN_MAGIC) - 1 + 2];

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -1,6 +1,7 @@
 #include "signMessage.h"
 #include "os.h"
 #include "utils.h"
+#include "blake2b.h"
 
 static char message[0xFC];
 static uint32_t accountNumber;
@@ -26,12 +27,10 @@ static unsigned int io_seproxyhal_touch_signMessage_ok(const bagl_element_t *e) 
     os_memmove(message + messageLength, data, dataLength);
     messageLength += dataLength;
 
-    sign(
-        accountNumber,
-        message,
-        messageLength,
-        G_io_apdu_buffer
-    );
+    uint8_t hash[32];
+    blake2b(&hash, 32, message, messageLength);
+
+    sign(accountNumber, hash, 32, G_io_apdu_buffer);
     sendResponse(64, true);
     return 0; // do not redraw the widget
 }

--- a/src/signTransaction.c
+++ b/src/signTransaction.c
@@ -11,7 +11,7 @@ static char payload[80];
 static uint32_t accountNumber;
 static uint32_t remainTransactionLength;
 static char networkId[NETWORK_ID_MAX_LENGTH + 1];
-cx_blake2b_t hash;
+static cx_blake2b_t hash;
 static txType transactionType;
 
 static void singAndSend() {


### PR DESCRIPTION
In sdk it has been changed in 2020 and I've just noticed that we didn't update it in Ledger app 🤦‍♀️ 

https://github.com/aeternity/aepp-sdk-js/blob/b1a94e3a874d2633b7a85253aef4176c8c96a7db/src/utils/crypto.ts#L155-L163